### PR TITLE
UnicodeEncodeError if non ascii value is submited

### DIFF
--- a/src/yota/validators.py
+++ b/src/yota/validators.py
@@ -1,6 +1,21 @@
+# encoding: utf-8
+from __future__ import unicode_literals
 import logging
 import re
 from yota.exceptions import NotCallableException
+
+import sys
+if sys.version_info[0] == 2:
+    string_types = (str, unicode)
+else:
+    string_types = (str,)
+
+def strplz(obj):
+    if isinstance(obj, string_types):
+        return obj
+    else:
+        return str(obj)
+
 
 class MinLengthValidator(object):
     """ Checks to see if data is at least length long.
@@ -20,7 +35,7 @@ class MinLengthValidator(object):
         super(MinLengthValidator, self).__init__()
 
     def __call__(self, target):
-        if len(str(target.data)) < self.min_length:
+        if len(strplz(target.data)) < self.min_length:
             target.add_error({'message': self.message})
 
 
@@ -42,7 +57,7 @@ class MaxLengthValidator(object):
         super(MaxLengthValidator, self).__init__()
 
     def __call__(self, target):
-        if len(str(target.data)) > self.max_length:
+        if len(strplz(target.data)) > self.max_length:
             target.add_error({'message': self.message})
 
 
@@ -117,7 +132,7 @@ class MinMaxValidator(object):
         super(MinMaxValidator, self).__init__()
 
     def __call__(self, target):
-        if len(str(target.data)) < self.min or len(str(target.data)) > self.max:
+        if len(strplz(target.data)) < self.min or len(strplz(target.data)) > self.max:
             target.add_error({'message': self.message})
 
 
@@ -209,7 +224,7 @@ class StrongPasswordValidator(object):
         for regex in self.regex:
             if re.match(regex, target.data):
                 strength += 1
-        target.add_error({'message': "Password strength is " + str(strength),
+        target.add_error({'message': "Password strength is " + strplz(strength),
                           'block': False})
 
 


### PR DESCRIPTION
If you fill form with non ascii symbols (for example russian) it fail with this traceback:

```
Traceback (most recent call last):
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1836, in __call__
    return self.wsgi_app(environ, start_response)
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/werkzeug/wsgi.py", line 579, in __call__
    return self.app(environ, start_response)
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1820, in wsgi_app
    response = self.make_response(self.handle_exception(e))
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1403, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1817, in wsgi_app
    response = self.full_dispatch_request()
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1477, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1381, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1475, in full_dispatch_request
    rv = self.dispatch_request()
  File "/Users/xen/Dev/water/cabinet/venv/lib/python2.7/site-packages/flask/app.py", line 1461, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/Users/xen/Dev/water/cabinet/water/registry/views.py", line 96, in contract
    success, out = form.validate_render(request.form)
  File "/Users/xen/Dev/water/cabinet/venv/src/yota/src/yota/__init__.py", line 513, in validate_render
    block, invalid = self._gen_validate(data)
  File "/Users/xen/Dev/water/cabinet/venv/src/yota/src/yota/__init__.py", line 388, in _gen_validate
    check.validate()
  File "/Users/xen/Dev/water/cabinet/venv/src/yota/src/yota/validators.py", line 411, in validate
    return self.validator(*self.args, **self.kwargs)
  File "/Users/xen/Dev/water/cabinet/venv/src/yota/src/yota/validators.py", line 47, in __call__
    if len(str(target.data)) > self.max_length:
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```

I've fixed code that tries to convert unicode strings using str function. Not fully sure about py3 version, since I don't yet switched to in on this project. But for me it at least fixed problem with other languages. 
